### PR TITLE
Added an option called `dragOnMove`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ components/
 bower_components/
 node_modules/
 build/
+.idea/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,21 @@
 
 Rad because it supports IE8+ and multi-touch.
 
+
+## About this Fork
+
+This fork changes only one thing: how `dragStart` fires. In draggabilly main, [`dragStart` fires on mouse down, right away, and the actual mouse down event is canceled](https://github.com/desandro/draggabilly/issues/13).
+
+Whenever you want an item to do one thing when you click it (say, select it), and a different thing when you drag it (say, move it), the existing event system will cause some issues.
+The mousedown event is needed to fire checkboxes, select boxes, dismiss modals, select list items, and many other things you might do in an application.
+
+I think `dragStart` should only fire when you begin to drag the element, not right when you click it, and that is what this fork does.
+
+This new feature is only active if you set the `dragOnMove` option, so this is not a breaking change.
+
+    var draggie = new Draggabilly( el, { dragOnMove: true } );
+
+
 ## Install
 
 Grab a packaged source file:

--- a/draggabilly.js
+++ b/draggabilly.js
@@ -255,7 +255,7 @@ Draggabilly.prototype.onmousedown = function( event ) {
   if ( button && ( button !== 0 && button !== 1 ) ) {
     return;
   }
-  this.dragStart( event, event );
+  this.watchForDrag( event, event );
 };
 
 Draggabilly.prototype.ontouchstart = function( event ) {
@@ -263,8 +263,7 @@ Draggabilly.prototype.ontouchstart = function( event ) {
   if ( this.isDragging ) {
     return;
   }
-
-  this.dragStart( event, event.changedTouches[0] );
+  this.watchForDrag( event, event.changedTouches[0] );
 };
 
 Draggabilly.prototype.onMSPointerDown =
@@ -273,8 +272,7 @@ Draggabilly.prototype.onpointerdown = function( event ) {
   if ( this.isDragging ) {
     return;
   }
-
-  this.dragStart( event, event );
+  this.watchForDrag( event, event );
 };
 
 function setPointerPoint( point, pointer ) {
@@ -291,15 +289,16 @@ var postStartEvents = {
 };
 
 /**
- * drag start
+ * Called on mousedown or touchstart. If this.options.dragOnMove, doesn't count as an actual drag unless the mouse moves.
  * @param {Event} event
  * @param {Event or Touch} pointer
  */
-Draggabilly.prototype.dragStart = function( event, pointer ) {
+Draggabilly.prototype.watchForDrag = function( event, pointer ) {
   if ( !this.isEnabled ) {
     return;
   }
 
+  // Should we prevent the default mousedown/touchstart event?
   if ( event.preventDefault ) {
     event.preventDefault();
   } else {
@@ -335,11 +334,25 @@ Draggabilly.prototype.dragStart = function( event, pointer ) {
     node: event.preventDefault ? window : document
   });
 
+  // Should we start the drag right away (legacy behavior), or wait for a mouse move?
+  if ( !this.options.dragOnMove ) {
+    this.dragStart(event, pointer);
+  }
+};
+
+/**
+ * drag start
+ * @param {Event} event
+ * @param {Event or Touch} pointer
+ */
+Draggabilly.prototype.dragStart = function( event, pointer ) {
+
   classie.add( this.element, 'is-dragging' );
 
   // reset isDragging flag
   this.isDragging = true;
 
+  event.draggabillyEvent = 'dragStart'; // Allows a handler to differentiate draggabilly event callbacks if they'd like to.
   this.emitEvent( 'dragStart', [ this, event, pointer ] );
 
   // start animation
@@ -421,6 +434,12 @@ Draggabilly.prototype.ontouchmove = function( event ) {
  */
 Draggabilly.prototype.dragMove = function( event, pointer ) {
 
+  // If we are in dragMove but not yet dragging, it's because a listener was set up but the actual drag hasn't started. Start it up!
+  if ( !this.isDragging ) {
+    this.dragStart( event, pointer ); // TODO: Should I maintain the original mousedown event and pass that here, or is it OK to be 1px or so off the initial position?
+                                      // eg: this.dragStart.apply(this.startingArgs);
+  }
+
   setPointerPoint( this.dragPoint, pointer );
   var dragX = this.dragPoint.x - this.startPoint.x;
   var dragY = this.dragPoint.y - this.startPoint.y;
@@ -445,6 +464,7 @@ Draggabilly.prototype.dragMove = function( event, pointer ) {
   this.dragPoint.x = dragX;
   this.dragPoint.y = dragY;
 
+  event.draggabillyEvent = 'dragMove';
   this.emitEvent( 'dragMove', [ this, event, pointer ] );
 };
 
@@ -492,6 +512,7 @@ Draggabilly.prototype.ontouchend = function( event ) {
  * @param {Event or Touch} pointer
  */
 Draggabilly.prototype.dragEnd = function( event, pointer ) {
+
   this.isDragging = false;
 
   delete this.pointerIdentifier;
@@ -507,7 +528,9 @@ Draggabilly.prototype.dragEnd = function( event, pointer ) {
 
   classie.remove( this.element, 'is-dragging' );
 
+  event.draggabillyEvent = 'dragEnd';
   this.emitEvent( 'dragEnd', [ this, event, pointer ] );
+
 
 };
 

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
     }
 
     .is-dragging {
-      opacity: 0.5;
+      opacity: 0.7;
       /* hack for artifacts http://stackoverflow.com/a/12023155 */
       -webkit-backface-visibility: hidden;
     }
@@ -105,6 +105,21 @@
       left: 400px;
     }
 
+    .eventExposer {
+      position: absolute;
+      width: 200px;
+      height: 100px;
+      left: 400px;
+      top: 520px;
+      /* Prevent the text contents of draggable elements from being selectable. */
+      -moz-user-select: none;
+      -khtml-user-select: none;
+      -webkit-user-select: none;
+      user-select: none;
+    }
+    #EventExposer1 { background: palegreen; }
+    #EventExposer2 { background: paleturquoise; top: 630px; }
+
     #axis-x { top: 160px; }
 
     #axis-y { top: 230px; }
@@ -154,6 +169,9 @@
 
   <div id="axis-x" class="axised">axis: x</div>
   <div id="axis-y" class="axised">axis: y</div>
+
+  <pre id="EventExposer1" class="eventExposer">dragOnMove: true</pre>
+  <pre id="EventExposer2" class="eventExposer">Events</pre>
 
 <script src="bower_components/eventEmitter/EventEmitter.js"></script>
 <script src="bower_components/eventie/eventie.js"></script>
@@ -234,8 +252,31 @@ window.onload = function() {
     });
   })();
 
+
   new Draggabilly( '#axis-x', { axis: 'x' });
   new Draggabilly( '#axis-y', { axis: 'y' });
+
+  // Show The events on the Draggie while they're happening.
+  var exposeEvent = function ( instance, event, pointer ) {
+    instance.element.innerHTML =    'DOM Event:   ' + event.type + '<br/>';
+    if ( event.draggabillyEvent ){
+      instance.element.innerHTML += 'Draggabilly: ' + event.draggabillyEvent;
+    }
+  };
+
+  var el1 = document.getElementById('EventExposer1');
+  var ee1 = new Draggabilly( el1, { dragOnMove:true } );
+  ee1.on( 'mouseDown', exposeEvent );
+  ee1.on( 'dragStart', exposeEvent );
+  ee1.on( 'dragMove',  exposeEvent );
+  ee1.on( 'dragEnd',   exposeEvent );
+
+  var el2 = document.getElementById('EventExposer2');
+  var ee2 = new Draggabilly( el2 );
+  ee2.on( 'mouseDown', exposeEvent );
+  ee2.on( 'dragStart', exposeEvent );
+  ee2.on( 'dragMove',  exposeEvent );
+  ee2.on( 'dragEnd',   exposeEvent );
 
 };
 </script>


### PR DESCRIPTION
If this option is set to true, the `dragStart` event doesn't fire until there is a mousemove on the draggable element.

Looks like a lot of code but most of it is on the test page and readme.

I'd also like to look at canceling the click event if a real drag happened, but that involved some interesting timing issues so I delayed it. This part is straightforward I think. Addresses Issue [#13](https://github.com/desandro/draggabilly/issues/13).