### PR TITLE
Added the ability to pass an element as the handle

### DIFF
--- a/draggabilly.js
+++ b/draggabilly.js
@@ -140,8 +140,7 @@ Draggabilly.prototype._create = function() {
  * set this.handles and bind start events to 'em
  */
 Draggabilly.prototype.setHandles = function() {
-  this.handles = this.options.handle ?
-    this.element.querySelectorAll( this.options.handle ) : [ this.element ];
+  this.handles = (typeof this.options.handle !== 'string' ? [this.options.handle] : (this.options.handle ? this.element.querySelectorAll(this.options.handle) : [this.element]));
 
   for ( var i=0, len = this.handles.length; i < len; i++ ) {
     var handle = this.handles[i];


### PR DESCRIPTION
Added the ability to pass an element as the handle. This enables Polymer ShadowDom elements to be used as the handle as well. Or just passing an element directly if you don't want it to use querySelectorAll();