### PR TITLE
Cannot use as AMD module

### DIFF
--- a/draggabilly.js
+++ b/draggabilly.js
@@ -17,7 +17,7 @@
         'unidragger/unidragger'
       ],
       function( classie, getStyleProperty, getSize, Unidragger ) {
-        factory( window, classie, getStyleProperty, getSize, Unidragger );
+        return factory( window, classie, getStyleProperty, getSize, Unidragger );
       });
   } else if ( typeof exports == 'object' ) {
     // CommonJS


### PR DESCRIPTION
Missing return statement to export as AMD module.

Example + fixed example: http://codepen.io/anon/pen/GJKpNJ