### PR TITLE
Allows containment to be restricted to a single axis

### DIFF
--- a/draggabilly.js
+++ b/draggabilly.js
@@ -350,6 +350,9 @@ proto.containDrag = function( axis, drag, grid ) {
   if ( !this.options.containment ) {
     return drag;
   }
+  if (this.options.containmentAxis && this.options.containmentAxis !== axis) {
+    return drag;
+  }
   var measure = axis == 'x' ? 'width' : 'height';
 
   var rel = this.relativeStartPosition[ axis ];


### PR DESCRIPTION
My use case a gantt chart where I'd like the ability to drag outside the container on the x-axis but to be contained on the y-axis.
Maybe an edge case but this PR allows containment restriction to be applied to a single axis.

Example usage:

``` javascript
var draggie = new Draggabilly(document.querySelector('.draggable-element'), {
   containment: document.querySelector('.wrapper-element'),
   containmentAxis: 'y'
});
```
