### PR TITLE
Fix #131

### DIFF
--- a/draggabilly.js
+++ b/draggabilly.js
@@ -187,6 +187,10 @@ Draggabilly.prototype._getPosition = function() {
 };
 
 Draggabilly.prototype._getPositionCoord = function( styleSide, measure ) {
+  if( this.element.parentNode === null ) {
+    return 0;
+  }
+  
   if ( styleSide.indexOf('%') != -1 ) {
     // convert percent into pixel for Safari, #75
     var parentSize = getSize( this.element.parentNode );


### PR DESCRIPTION
Making _getPositionCoord return a dummy zero when there is no parent element (i.e. draggable element hasn't been attached tot he DOM tree yet) suppresses the error from #131.

The test system seems to be behaving a little oddly on my setup, but this change behaved identically to the master branch aside from #131, so I think it's good.
