### PR TITLE
added positionByTransform option

### DIFF
--- a/draggabilly.js
+++ b/draggabilly.js
@@ -131,7 +131,7 @@ proto._create = function() {
 
   this.startPoint = { x: 0, y: 0 };
   this.dragPoint = { x: 0, y: 0 };
-  this.startCoords = { left: '', top: '' };
+  this.startCoords = { x: 0, y: 0 };
 
   this.startPosition = extend( {}, this.position );
 
@@ -184,8 +184,10 @@ proto.dispatchEvent = function( type, event, args ) {
 
 proto._getStartCoords = function() {
   var style = getComputedStyle( this.element );
-  this.startCoords.left = style.left;
-  this.startCoords.top = style.top;
+  var x = parseInt( style.left, 10 );
+  var y = parseInt( style.top, 10 );
+  this.startCoords.x = isNaN( x ) ? 0 : x;
+  this.startCoords.y = isNaN( y ) ? 0 : y;
 };
 
 // get x/y position from style
@@ -437,10 +439,11 @@ proto.setLeftTop = function() {
 
 // transform positioning
 proto.setTransformPosition = function() {
-  this.element.style.left = this.startCoords.left;
-  this.element.style.top  = this.startCoords.top;
-  this.element.style[ transformProperty ] = 'translate3d( ' + this.position.x +
-    'px, ' + this.position.y + 'px, 0)';
+  this.element.style.left = this.startCoords.x + 'px';
+  this.element.style.top  = this.startCoords.y + 'px';
+  this.element.style[ transformProperty ] = 'translate3d( ' +
+    ( this.position.x - this.startCoords.x ) + 'px, ' +
+    ( this.position.y - this.startCoords.y ) + 'px, 0)';
 };
 
 proto.positionDrag = function() {

--- a/draggabilly.js
+++ b/draggabilly.js
@@ -131,6 +131,7 @@ proto._create = function() {
 
   this.startPoint = { x: 0, y: 0 };
   this.dragPoint = { x: 0, y: 0 };
+  this.startCoords = { left: '', top: '' };
 
   this.startPosition = extend( {}, this.position );
 
@@ -180,6 +181,12 @@ proto.dispatchEvent = function( type, event, args ) {
 };
 
 // -------------------------- position -------------------------- //
+
+proto._getStartCoords = function() {
+  var style = getComputedStyle( this.element );
+  this.startCoords.left = style.left;
+  this.startCoords.top = style.top;
+};
 
 // get x/y position from style
 proto._getPosition = function() {
@@ -263,6 +270,7 @@ proto.dragStart = function( event, pointer ) {
   if ( !this.isEnabled ) {
     return;
   }
+  this._getStartCoords();
   this._getPosition();
   this.measureContainment();
   // position _when_ drag began
@@ -389,10 +397,16 @@ proto.dragEnd = function( event, pointer ) {
   if ( !this.isEnabled ) {
     return;
   }
-  // use top left position when complete
+
   if ( transformProperty ) {
     this.element.style[ transformProperty ] = '';
-    this.setLeftTop();
+    if ( this.options.positionByTransform ) {
+      // use original top left position plus occurred transformation
+      this.setTransformPosition();
+    } else {
+      // use top left position when complete
+      this.setLeftTop();
+    }
   }
   this.element.classList.remove('is-dragging');
   this.dispatchEvent( 'dragEnd', event, [ pointer ] );
@@ -419,6 +433,14 @@ proto.animate = function() {
 proto.setLeftTop = function() {
   this.element.style.left = this.position.x + 'px';
   this.element.style.top  = this.position.y + 'px';
+};
+
+// transform positioning
+proto.setTransformPosition = function() {
+  this.element.style.left = this.startCoords.left;
+  this.element.style.top  = this.startCoords.top;
+  this.element.style[ transformProperty ] = 'translate3d( ' + this.position.x +
+    'px, ' + this.position.y + 'px, 0)';
 };
 
 proto.positionDrag = function() {

--- a/draggabilly.js
+++ b/draggabilly.js
@@ -410,8 +410,13 @@ proto.dragEnd = function( event, pointer ) {
       this.setLeftTop();
     }
   }
-  this.element.classList.remove('is-dragging');
-  this.dispatchEvent( 'dragEnd', event, [ pointer ] );
+
+  // force repaint to avoid side-effect related to 'is-dragging' class removal
+  var _this = this;
+  setTimeout(function() {
+    _this.element.classList.remove('is-dragging');
+    _this.dispatchEvent( 'dragEnd', event, [ pointer ] );
+  }, 0);
 };
 
 // -------------------------- animation -------------------------- //


### PR DESCRIPTION
I'm not sure if that will make sense to you, but I'm using your (great!) lib along with some additional logic to make smooth repositioning of cards the same way Google Keep does. It is working great. But to achieve this, all my elements inside the container have left and top zero, and are positioned by the transform property. So I had to add an option to your lib to position the elements on drag end by the transform property instead of top/left properties. This patch doesn't change the default behavior.
